### PR TITLE
Fix: Resolve duplicate directive error in DeviceApiHandler.smali

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/Network/DeviceApiHandler.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/Network/DeviceApiHandler.smali
@@ -36,8 +36,6 @@
     # v10: final_response_string / temp for static error strings
     # v12: exception_object (for catch blocks)
 
-    .locals 13 # Corrected .locals declaration
-
     const-string v0, "http://your_domain_or_ip:5001/api/check_device_status?deviceId="
 
     move-object v4, v11 # Initialize http_connection to null


### PR DESCRIPTION
Corrected an error in `com.rtx.nextvproject.RTX.Network.DeviceApiHandler.smali` where a duplicate or misplaced `.locals` directive was present within the `checkDeviceStatus` method.

Removed the offending directive to ensure only a single, correctly placed `.locals` (or `.registers`) directive exists at the beginning of the method, as per Smali syntax rules. This resolves the "There can only be a single .registers or .locals directive in a method" error.