### PR TITLE
Fix: Correct Device ID dialog flow and task initiation

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
@@ -167,42 +167,6 @@
 
     sput-object v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->_qgdrndckndjdkde:Ljava/lang/String;
 
-    .line 46
-    new-instance v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;
-
-    const/4 v1, 0x0
-
-    invoke-direct {v0, p0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;-><init>(Lcom/rtx/nextvproject/RTX/UI/SplashRTX;Lcom/rtx/nextvproject/RTX/UI/SplashRTX$1;)V
-
-    const/4 v1, 0x1
-
-    new-array v1, v1, [Ljava/lang/String;
-
-    new-instance v2, Ljava/lang/StringBuilder;
-
-    invoke-direct {v2}, Ljava/lang/StringBuilder;-><init>()V
-
-    sget-object v3, Lcom/rtx/nextvproject/RTX/mConfig;->mApiUrl:Ljava/lang/String;
-
-    invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-
-    const-string v3, "api/dns.php"
-
-    invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-
-    invoke-virtual {v2}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
-
-    move-result-object v2
-
-    const/4 v3, 0x0
-
-    aput-object v2, v1, v3
-
-    invoke-virtual {v0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;->execute([Ljava/lang/Object;)Landroid/os/AsyncTask;
-
-    .line 47
-    invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->downImage()V
-
     .line 49
     # Original return-void will be moved to the end of originalOnCreateLogicOrShowDialog
     # return-void
@@ -325,19 +289,13 @@
 .end method
 
 .method continueWithAppLogic(Landroid/os/Bundle;)V
-    .locals 4 # Increased to 4 for v3
+    .locals 4 # Max register used is v3, so 4 locals
     .param p1, "savedInstanceState"    # Landroid/os/Bundle;
 
-    # This method contains the original logic from onCreate
-    invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V
-
-    const v0, 0x7f0e0108
-    invoke-virtual {p0, v0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->setContentView(I)V
-
-    sput-object p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->context:Landroid/content/Context;
-
-    const-string v0, ""
-    sput-object v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->_qgdrndckndjdkde:Ljava/lang/String;
+    .prologue
+    # Application specific logic starts here
+    # HttpsGetTask and downImage calls were already here from a previous refactoring.
+    # We are removing super.onCreate, setContentView, and static field inits from this method.
 
     new-instance v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;
 


### PR DESCRIPTION
This commit addresses issues with the Device ID prompt introduced in the previous fix:
- Dialog disappearing too quickly / app proceeding without ID.
- Dialog appearing on every app launch.

Changes Made:

1.  **Modified `SplashRTX.smali` (`onCreate`):**
    - Removed the unconditional start of `SplashRTX$HttpsGetTask` and `downImage()` call. These tasks are now started only after Device ID is confirmed.

2.  **Modified `SplashRTX.smali` (`continueWithAppLogic`):**
    - Removed redundant calls to `super.onCreate()` and `setContentView()`.
    - This method now correctly initiates `SplashRTX$HttpsGetTask` and calls `downImage()`. This is called when a Device ID already exists or has just been saved.

3.  **`SplashRTX$2.smali` (Save Listener):**
    - No changes were needed in this iteration. It correctly calls `continueWithAppLogic` which now handles task starting.

This revised flow ensures the Device ID dialog waits for your input, the main app logic and API calls only proceed after the Device ID is handled, and the Device ID should persist correctly, preventing the dialog from showing on every launch. This should also improve stability and prevent crashes related to the previous faulty flow.