### PR TITLE
Fix: Target Device ID verification to local development server

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/Network/DeviceApiHandler.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/Network/DeviceApiHandler.smali
@@ -36,7 +36,7 @@
     # v10: final_response_string / temp for static error strings
     # v12: exception_object (for catch blocks)
 
-    const-string v0, "http://your_domain_or_ip:5001/api/check_device_status?deviceId="
+    const-string v0, "http://10.0.2.2:5001/api/check_device_status?deviceId="
 
     move-object v4, v11 # Initialize http_connection to null
     move-object v7, v11 # Initialize buffered_reader to null


### PR DESCRIPTION
This commit corrects the API endpoint for the initial Device ID verification process based on your feedback.

Changes:
1.  Reverted `mApiUrl` in `mConfig.smali` back to its original production value ("https://thestreambuddy.tv/next/"). This ensures general API calls (e.g., for DNS configuration) correctly target the production environment.

2.  Modified the `checkDeviceStatus` method in `DeviceApiHandler.smali`. The hardcoded URL used for Device ID verification has been changed from a placeholder to "http://10.0.2.2:5001/api/check_device_status?deviceId=". This directs the specific device verification call to your local development server, using the standard emulator IP for host localhost access and HTTP.

This should resolve the issue where the initial Device ID verification was not hitting the local server as intended.