### PR TITLE
Fix: Update Device ID verification URL to use 127.0.0.1

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/Network/DeviceApiHandler.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/Network/DeviceApiHandler.smali
@@ -36,7 +36,7 @@
     # v10: final_response_string / temp for static error strings
     # v12: exception_object (for catch blocks)
 
-    const-string v0, "http://10.0.2.2:5001/api/check_device_status?deviceId="
+    const-string v0, "http://127.0.0.1:5001/api/check_device_status?deviceId="
 
     move-object v4, v11 # Initialize http_connection to null
     move-object v7, v11 # Initialize buffered_reader to null


### PR DESCRIPTION
Per your feedback, the IP address for the local Device ID verification endpoint has been changed from 10.0.2.2 to 127.0.0.1.

The `checkDeviceStatus` method in `DeviceApiHandler.smali` now uses the URL "http://127.0.0.1:5001/api/check_device_status?deviceId=". This ensures the verification call targets the correct loopback address for local development setups where the server is running on the same device as the application.