### PR TITLE
Here's a diagnostic commit to help pinpoint why the app closes/crashe…

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX$2.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX$2.smali
@@ -98,16 +98,17 @@
     .line 10
     invoke-interface {v1}, Landroid/content/SharedPreferences$Editor;->apply()V
 
-    .line 11
-    invoke-interface {p1}, Landroid/content/DialogInterface;->dismiss()V
+    # Dialog dismiss REMOVED for this test
+    # invoke-interface {p1}, Landroid/content/DialogInterface;->dismiss()V
 
-    .line 12
+    # Call to continueWithAppLogic REMOVED for this test
+    # iget-object v1, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$2;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX;
+    # const/4 v2, 0x0 # null for Bundle argument
+    # invoke-direct {v1, v2}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
+
+    # ADDED finish() call to isolate SharedPreferences save
     iget-object v1, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$2;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX;
+    invoke-virtual {v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
 
-    const/4 v2, 0x0
-
-    invoke-direct {v1, v2}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
-    # Corrected to invoke-direct as per subtask for package-private visibility
-    # Previous was: invoke-virtual {v1, v2}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
     goto :goto_0
 .end method

--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
@@ -293,39 +293,7 @@
     .param p1, "savedInstanceState"    # Landroid/os/Bundle;
 
     .prologue
-    # Application specific logic starts here
-    # HttpsGetTask and downImage calls were already here from a previous refactoring.
-    # We are removing super.onCreate, setContentView, and static field inits from this method.
-
-    new-instance v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;
-
-    const/4 v1, 0x0
-    invoke-direct {v0, p0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;-><init>(Lcom/rtx/nextvproject/RTX/UI/SplashRTX;Lcom/rtx/nextvproject/RTX/UI/SplashRTX$1;)V
-
-    const/4 v1, 0x1
-    new-array v1, v1, [Ljava/lang/String;
-
-    new-instance v2, Ljava/lang/StringBuilder;
-
-    invoke-direct {v2}, Ljava/lang/StringBuilder;-><init>()V
-
-    sget-object v3, Lcom/rtx/nextvproject/RTX/mConfig;->mApiUrl:Ljava/lang/String; # Using v3 for mApiUrl
-    invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-    move-result-object v2 # Re-assign to v2 as append returns the builder
-
-    const-string v3, "api/dns.php" # Using v3 for "api/dns.php" string
-    invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-    move-result-object v2 # Re-assign to v2
-
-    invoke-virtual {v2}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
-    move-result-object v2 # v2 now holds the final URL string
-
-    const/4 v3, 0x0 # Using v3 for the integer 0 (array index)
-    aput-object v2, v1, v3 # Store final URL string (v2) into String array (v1) at index 0 (v3)
-
-    invoke-virtual {v0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;->execute([Ljava/lang/Object;)Landroid/os/AsyncTask;
-
-    invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->downImage()V
+    # Temporarily removed HttpsGetTask and downImage calls for debugging.
 
     return-void
 .end method


### PR DESCRIPTION
…s immediately after you save a Device ID.

Changes:
1.  In `SplashRTX.smali`, I've temporarily emptied the `continueWithAppLogic` method (its operational code removed). This is to test if the tasks normally started by this method are the cause of an immediate crash.

2.  In `SplashRTX$2.smali` (Save button listener for Device ID dialog):
    - I've temporarily removed the call to `DialogInterface.dismiss()`.
    - I've temporarily removed the call to `continueWithAppLogic`.
    - I've added a call to `finish()` on the SplashRTX activity immediately after `SharedPreferences.Editor.apply()`.

To help with this, I'll run through the following scenario:
1.  First Launch: I'll enter a Device ID and click Save.
    - Expected: The app should save the ID, then SplashRTX should finish (close).
    - I'll observe: Does it crash or close cleanly?
2.  Second Launch: I'll relaunch the app.
    - Expected: The dialog should not show. `continueWithAppLogic` (now empty) should be called. The app should remain on the Splash screen without crashing.
    - I'll observe: The behavior after relaunch.

These changes will help determine if the crash is within the SharedPreferences save itself, dialog dismissal, or the subsequent `continueWithAppLogic` call.