### PR TITLE
I've made a diagnostic change to see if using a synchronous method fo…

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX$2.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX$2.smali
@@ -96,19 +96,21 @@
     invoke-interface {v1, v2, v0}, Landroid/content/SharedPreferences$Editor;->putString(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;
 
     .line 10
-    invoke-interface {v1}, Landroid/content/SharedPreferences$Editor;->apply()V
+    # Using commit() instead of apply() for this test
+    invoke-interface {v1}, Landroid/content/SharedPreferences$Editor;->commit()Z # Boolean result is ignored
 
-    # Dialog dismiss REMOVED for this test
-    # invoke-interface {p1}, Landroid/content/DialogInterface;->dismiss()V
+    .line 11
+    # Dialog dismiss should be PRESENT
+    invoke-interface {p1}, Landroid/content/DialogInterface;->dismiss()V
 
-    # Call to continueWithAppLogic REMOVED for this test
+    # Call to continueWithAppLogic remains REMOVED
     # iget-object v1, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$2;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX;
     # const/4 v2, 0x0 # null for Bundle argument
     # invoke-direct {v1, v2}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
 
-    # ADDED finish() call to isolate SharedPreferences save
-    iget-object v1, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$2;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX;
-    invoke-virtual {v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    # finish() call (from previous diag step) also remains REMOVED from this path
+    # iget-object v1, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$2;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX;
+    # invoke-virtual {v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
 
     goto :goto_0
 .end method


### PR DESCRIPTION
…r saving preferences has any effect on the app closing or crashing immediately after saving the Device ID.

Here's what I modified:

1.  In the save button listener code (`SplashRTX$2.smali`):
    - When you enter a non-empty Device ID, I now save the changes using a synchronous commit.
    - The dialog will be dismissed after attempting the save.
    - For this diagnostic test, the parts of the code that would normally continue with the app's logic and close the screen remain disabled.

2.  The `continueWithAppLogic` method in `SplashRTX.smali` is still temporarily empty from previous diagnostic steps.

Here's how you can test this (Test Scenario 5):
1.  First Launch: Enter a Device ID and click Save.
    - Expected: The dialog should dismiss, and the app should remain on the Splash screen.
    - Please observe: Does it crash or close cleanly? Is it stable?
2.  Second Launch: Relaunch the app.
    - Expected: The dialog should NOT appear (if the save worked). The (currently empty) `continueWithAppLogic` method will be called. The app should remain on the Splash screen and be stable.
    - Please observe: Note the behavior after you relaunch the app.