### PR TITLE
I'm currently working on a diagnostic to understand app stability whe…

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
@@ -204,8 +204,10 @@
     return-void
 
 :cond_proceed_original_logic
-    # Call method to continue with original app logic
-    invoke-direct {p0, p1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
+    # Call method to continue with original app logic - REMOVED for diagnostics
+    # invoke-direct {p0, p1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
+
+    # For diagnostic purposes, if device_id is found, just return.
     return-void
 .end method
 


### PR DESCRIPTION
…n a Device ID is found at startup.

I've made some modifications to `SplashRTX.smali` to isolate a crash that occurs on the second launch of the app, after a Device ID has been previously saved.

Here are the changes:
1.  In `SplashRTX.smali` (specifically, the `originalOnCreateLogicOrShowDialog` method):
    - If a `device_id` is found in SharedPreferences, the method will now take no further action and return. I've temporarily removed the call to `continueWithAppLogic` in this scenario.
    - The path for when no `device_id` is found (which involves calling `showDeviceIdDialog`) remains unchanged.
2.  The `continueWithAppLogic` method in `SplashRTX.smali` remains empty from previous diagnostic steps, meaning no tasks are started there.
3.  In `SplashRTX$2.smali` (which handles the Save button):
    - This part continues to save the Device ID, dismisses the dialog, and then calls the (empty) `continueWithAppLogic()`. The stability of this sequence on the first launch was confirmed in a previous step.

Here's the test scenario I'm running (Test Scenario 6):
1.  First Launch (after clearing data): You'll enter the Device ID and click Save.
    - I expect the dialog to dismiss, the app to call the empty `continueWithAppLogic`, and the app to remain stable on the Splash screen.
2.  Second Launch: You'll relaunch the app.
    - I expect the `device_id` to be found. The `originalOnCreateLogicOrShowDialog` method should now do nothing and return. The app should remain stable on the Splash screen and NOT crash. The dialog should not reappear.

My goal with this test is to determine if the crash on the second launch is related to the call to `continueWithAppLogic` from `originalOnCreateLogicOrShowDialog` or actions taken immediately after finding an existing Device ID.