### PR TITLE
I've made some modifications to `SplashRTX.smali` to test the stabili…

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
@@ -204,10 +204,14 @@
     return-void
 
 :cond_proceed_original_logic
-    # Call method to continue with original app logic - REMOVED for diagnostics
-    # invoke-direct {p0, p1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
+    # Restoring call to continueWithAppLogic, but with a null Bundle argument.
+    # p0 is 'this' SplashRTX instance.
+    # p1 is the original Bundle from onCreate, which we are NOT passing here.
 
-    # For diagnostic purposes, if device_id is found, just return.
+    const/4 v3, 0x0 # Using v3 for the null Bundle argument. .locals 5 is defined for the method.
+
+    invoke-direct {p0, v3}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
+
     return-void
 .end method
 


### PR DESCRIPTION
…ty of calling `continueWithAppLogic` with a null Bundle argument from the `originalOnCreateLogicOrShowDialog` method when a Device ID is found during startup.

Here's what I changed:
1.  In `SplashRTX.smali` (within the `originalOnCreateLogicOrShowDialog` method):
    - If a `device_id` is found in SharedPreferences, I've restored the call to `continueWithAppLogic(Landroid/os/Bundle;)V`, but I'm now explicitly passing `null` as the Bundle argument.
2.  In the `SplashRTX.smali` file (within the `continueWithAppLogic` method):
    - This method remains empty from previous steps.
3.  In `SplashRTX$2.smali` (the Save button listener):
    - This listener remains unchanged from the previous step (it saves the ID, dismisses the dialog, and calls an empty `continueWithAppLogic(null)`).

Here's how I'll check this:
1.  First Launch (after you clear the data): You'll enter a Device ID and click Save.
    - I expect the dialog to dismiss, the app to call an empty `continueWithAppLogic(null)`, and the app to remain stable on the Splash screen.
2.  Second Launch: You'll relaunch the app.
    - I expect the `device_id` to be found. The `originalOnCreateLogicOrShowDialog` method will now call an empty `continueWithAppLogic(null)`. The app should remain stable on the Splash screen and not crash. The dialog should not reappear.

My goal here is to see if passing a null Bundle to `continueWithAppLogic` from the startup path resolves the crash you observed on the second launch in earlier attempts.