### PR TITLE
Diag: Directly launch TvActivity if Device ID is found

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
@@ -204,13 +204,20 @@
     return-void
 
 :cond_proceed_original_logic
-    # Restoring call to continueWithAppLogic, but with a null Bundle argument.
-    # p0 is 'this' SplashRTX instance.
-    # p1 is the original Bundle from onCreate, which we are NOT passing here.
+    # Bypassing continueWithAppLogic, directly launching TvActivity and finishing SplashRTX.
+    # p0 is 'this' SplashRTX activity.
+    # .locals 5 is defined for the method. v0, v1, v2 were used for SharedPreferences.
+    # Reusing v0 and v1 for Intent creation.
 
-    const/4 v3, 0x0 # Using v3 for the null Bundle argument. .locals 5 is defined for the method.
+    new-instance v0, Landroid/content/Intent; # v0 for the new Intent
 
-    invoke-direct {p0, v3}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
+    const-class v1, Lfr/nextv/atv/app/TvActivity; # v1 for TvActivity.class
+
+    invoke-direct {v0, p0, v1}, Landroid/content/Intent;-><init>(Landroid/content/Context;Ljava/lang/Class;)V
+
+    invoke-virtual {p0, v0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->startActivity(Landroid/content/Intent;)V
+
+    invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
 
     return-void
 .end method


### PR DESCRIPTION
This diagnostic commit modifies `SplashRTX.smali` to test app stability when a Device ID is found at startup. Instead of calling `continueWithAppLogic` (which was causing crashes even when empty when called from the startup path), it now attempts to directly launch `TvActivity`.

Changes:
1.  In `SplashRTX.smali` (`originalOnCreateLogicOrShowDialog` method):
    - If a `device_id` is found in SharedPreferences, the method now constructs an Intent for `fr.nextv.atv.app.TvActivity`, calls `startActivity()`, and then calls `finish()` on `SplashRTX`.
    - The call to `continueWithAppLogic` from this path is removed.
2.  `SplashRTX.smali` (`continueWithAppLogic` method):
    - This method remains empty.
3.  `SplashRTX$2.smali` (Save button listener):
    - Remains unchanged from the previous step: saves ID with `commit()`, dismisses dialog, calls empty `continueWithAppLogic()`.

Test Scenario (Test Scenario 8):
1.  First Launch (after clearing data): You enter Device ID, click Save.
    - Expected: Dialog dismisses, app calls empty `continueWithAppLogic()`, app remains stable on Splash screen.
2.  Second Launch: You relaunch app.
    - Expected: `device_id` is found. `originalOnCreateLogicOrShowDialog` now attempts to directly start `TvActivity` and then `SplashRTX` finishes. The Device ID dialog should not reappear.
    - Observe: Does `TvActivity` launch successfully, or does the app crash?