### PR TITLE
Feat: Implement full activation flow with local device check

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/Network/DeviceApiHandler.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/Network/DeviceApiHandler.smali
@@ -36,7 +36,7 @@
     # v10: final_response_string / temp for static error strings
     # v12: exception_object (for catch blocks)
 
-    const-string v0, "http://127.0.0.1:5001/api/check_device_status?deviceId="
+    const-string v0, "http://localhost:5001/api/check_device_status?deviceId="
 
     move-object v4, v11 # Initialize http_connection to null
     move-object v7, v11 # Initialize buffered_reader to null

--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask$1.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask$1.smali
@@ -41,7 +41,7 @@
 
 # virtual methods
 .method public run()V
-    .locals 3
+    .locals 6 # Increased locals for new logic (v0-v5)
 
     .line 62
     sget-object v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->rtxrebrand:Lcom/rtx/nextvproject/RTX/RTXArry;
@@ -57,6 +57,59 @@
     move-result-object v1
 
     invoke-static {v0, v1}, Lcom/rtx/nextvproject/RTX/RTX;->pushDNS(Lcom/rtx/nextvproject/RTX/RTXArry;Ljava/lang/String;)V
+
+    # ---- START OF DEVICE ID CHECK ----
+    # Get SplashRTX context (this$0 from this$1)
+    # Current v0 (rtxrebrand) and v1 (decryptedDnsString) are no longer needed.
+    # p0 is 'this' (SplashRTX$HttpsGetTask$1 instance)
+    iget-object v0, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask$1;->this$1:Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;
+    iget-object v0, v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX; # v0 is now SplashRTX context
+
+    # Read Device ID from SharedPreferences
+    const-string v1, "app_prefs"
+    const/4 v2, 0x0
+    invoke-virtual {v0, v1, v2}, Landroid/app/Activity;->getSharedPreferences(Ljava/lang/String;I)Landroid/content/SharedPreferences;
+    move-result-object v3 # v3 = SharedPreferences instance
+
+    const-string v4, "device_id"
+    const/4 v5, 0x0 # null string for default value
+    invoke-interface {v3, v4, v5}, Landroid/content/SharedPreferences;->getString(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+    move-result-object v1 # v1 = deviceId string from SharedPreferences
+
+    # Handle null deviceId
+    if-nez v1, :skip_finish_if_id_null_or_empty
+    invoke-virtual {v0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    return-void
+    :skip_finish_if_id_null_or_empty
+
+    # Handle empty deviceId
+    invoke-virtual {v1}, Ljava/lang/String;->isEmpty()Z
+    move-result v2 # v2 = isEmptyResult (boolean)
+    if-eqz v2, :id_not_empty_proceed_to_check # If isEmpty is false (0), then id is not empty, proceed.
+    invoke-virtual {v0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    return-void
+    :id_not_empty_proceed_to_check
+
+    # Call DeviceApiHandler.checkDeviceStatus
+    # v0 is SplashRTX context, v1 is device_id_str (non-null, non-empty)
+    invoke-static {v0, v1}, Lcom/rtx/nextvproject/RTX/Network/DeviceApiHandler;->checkDeviceStatus(Landroid/content/Context;Ljava/lang/String;)Ljava/lang/String;
+    move-result-object v1 # v1 now holds the JSON response string
+
+    # Check response for errors ("status":"error")
+    const-string v4, "\"status\":\"error\"" # v4 can be reused
+    invoke-virtual {v1, v4}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+    move-result v2 # v2 = contains_error (boolean)
+
+    if-eqz v2, :cond_no_error_proceed_to_tvactivity # If contains_error is false (0), no error, proceed to TvActivity launch
+
+    # Error found in response: Finish SplashRTX and return from this run() method
+    invoke-virtual {v0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    return-void
+
+    :cond_no_error_proceed_to_tvactivity
+    # No error, fall through to existing TvActivity launch code.
+    # Registers v0, v1, v2 will be reset by the following existing code.
+    # ---- END OF DEVICE ID CHECK ----
 
     .line 63
     new-instance v0, Landroid/content/Intent;

--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
@@ -204,20 +204,12 @@
     return-void
 
 :cond_proceed_original_logic
-    # Bypassing continueWithAppLogic, directly launching TvActivity and finishing SplashRTX.
-    # p0 is 'this' SplashRTX activity.
-    # .locals 5 is defined for the method. v0, v1, v2 were used for SharedPreferences.
-    # Reusing v0 and v1 for Intent creation.
+    # If device_id is found, call continueWithAppLogic with a null Bundle.
+    # p0 is 'this' (SplashRTX instance).
+    # .locals 5 is defined for the method. v0,v1,v2 used for SP. v3 for null.
 
-    new-instance v0, Landroid/content/Intent; # v0 for the new Intent
-
-    const-class v1, Lfr/nextv/atv/app/TvActivity; # v1 for TvActivity.class
-
-    invoke-direct {v0, p0, v1}, Landroid/content/Intent;-><init>(Landroid/content/Context;Ljava/lang/Class;)V
-
-    invoke-virtual {p0, v0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->startActivity(Landroid/content/Intent;)V
-
-    invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    const/4 v3, 0x0 # Using v3 for the null Bundle argument.
+    invoke-direct {p0, v3}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
 
     return-void
 .end method
@@ -306,7 +298,39 @@
     .param p1, "savedInstanceState"    # Landroid/os/Bundle;
 
     .prologue
-    # Temporarily removed HttpsGetTask and downImage calls for debugging.
+    # Restoring HttpsGetTask and downImage calls.
+    # .locals 4 is already defined for the method.
+    # p0 is 'this' SplashRTX instance.
+    # p1 (savedInstanceState) is not used in this restored logic.
+
+    # Start HttpsGetTask
+    new-instance v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;
+    const/4 v1, 0x0 # Second argument for HttpsGetTask constructor (SplashRTX$1)
+    invoke-direct {v0, p0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;-><init>(Lcom/rtx/nextvproject/RTX/UI/SplashRTX;Lcom/rtx/nextvproject/RTX/UI/SplashRTX$1;)V
+
+    const/4 v1, 0x1 # Create a 1-element String array
+    new-array v1, v1, [Ljava/lang/String;
+
+    new-instance v2, Ljava/lang/StringBuilder;
+    invoke-direct {v2}, Ljava/lang/StringBuilder;-><init>()V
+
+    # Get production API URL from mConfig
+    sget-object v3, Lcom/rtx/nextvproject/RTX/mConfig;->mApiUrl:Ljava/lang/String;
+    invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    const-string v3, "api/dns.php"
+    invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v2}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+    move-result-object v2
+
+    const/4 v3, 0x0 # Array index for the URL
+    aput-object v2, v1, v3
+
+    invoke-virtual {v0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;->execute([Ljava/lang/Object;)Landroid/os/AsyncTask;
+
+    # Call downImage
+    invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->downImage()V
 
     return-void
 .end method


### PR DESCRIPTION
This commit integrates the complete activation logic, including:
- Production API call for initial app/DNS configuration.
- Local Device ID verification against the developer's server.
- Consistent handling for first launch (ID entry) and subsequent launches (ID found in SharedPreferences).

Changes:
1.  `mConfig.smali`:
    - `mApiUrl` remains pointed to the production URL ("https://thestreambuddy.tv/next/").
2.  `DeviceApiHandler.smali`:
    - `checkDeviceStatus` URL is set to "http://localhost:5001/api/check_device_status?deviceId=" for local verification.
3.  `SplashRTX.smali`:
    - `continueWithAppLogic()`: Restored to initiate the `SplashRTX$HttpsGetTask` (for production `api/dns.php` call) and `downImage()`.
    - `originalOnCreateLogicOrShowDialog()`: If a `device_id` is found, it now calls `continueWithAppLogic(null)`, ensuring the same task sequence as a first launch post-ID-entry. If no ID is found, it calls `showDeviceIdDialog()`.
4.  `SplashRTX$2.smali` (Save button listener):
    - Continues to save `device_id` with `commit()`, dismisses dialog, and calls `continueWithAppLogic(null)`.
5.  `SplashRTX$HttpsGetTask$1.smali` (Callback for production HttpsGetTask):
    - After processing the production API response: - Reads `device_id` from SharedPreferences. - If `device_id` is null or empty, `SplashRTX` now finishes. - Calls `DeviceApiHandler.checkDeviceStatus()` (to the local server `http://localhost:5001/...`). - If the local check response contains ""status":"error"", `SplashRTX` now finishes (preventing `TvActivity` launch). - Otherwise (if local check is OK), it proceeds to launch `TvActivity`.

This set of changes should provide a comprehensive activation flow, correctly directing requests and handling responses from both production and local development servers as per the refined understanding of requirements.