### PR TITLE
Diag: Test with HttpsGetTask only in continueWithAppLogic

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
@@ -329,8 +329,8 @@
 
     invoke-virtual {v0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;->execute([Ljava/lang/Object;)Landroid/os/AsyncTask;
 
-    # Call downImage
-    invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->downImage()V
+    # Call downImage - Temporarily REMOVED for diagnostics
+    # invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->downImage()V
 
     return-void
 .end method


### PR DESCRIPTION
This diagnostic commit modifies `SplashRTX.smali`'s `continueWithAppLogic` method to only initiate the `SplashRTX$HttpsGetTask` (for the production api/dns.php call). The `downImage()` call has been temporarily commented out.

This is to isolate whether `SplashRTX$HttpsGetTask` alone, when called from `continueWithAppLogic` (either after initial Device ID save or on a subsequent launch when ID is found), is stable and whether the subsequent local device ID check in its callback (`SplashRTX$HttpsGetTask$1.smali`) functions as expected.

Other components remain configured for the full flow:
- `DeviceApiHandler.checkDeviceStatus` targets `http://localhost:5001/...`.
- `SplashRTX$HttpsGetTask$1.smali` attempts this local check before launching `TvActivity` or finishing `SplashRTX`.

Test Scenario (Test Scenario 10a):
1.  First Launch (clear data, local server ON for valid ID check): Enter ID, Save. Expected: Prod API call -> Local device check -> TvActivity.
2.  Second Launch (local server ON): Expected: No dialog -> Prod API call -> Local device check -> TvActivity.
3.  Third Launch (local server OFF or returns error for device check):
    Expected: No dialog -> Prod API call -> Local device check (fails) ->
    SplashRTX finishes, no TvActivity. Next launch should show dialog.