### PR TITLE
Hi there! I've made some changes to the application startup to focus …

### DIFF
--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX$2.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX$2.smali
@@ -103,14 +103,40 @@
     # Dialog dismiss should be PRESENT
     invoke-interface {p1}, Landroid/content/DialogInterface;->dismiss()V
 
-    # Call to continueWithAppLogic remains REMOVED
-    # iget-object v1, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$2;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX;
-    # const/4 v2, 0x0 # null for Bundle argument
-    # invoke-direct {v1, v2}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
+    # ---- START OF DEVICE ID CHECK & TVActivity LAUNCH ----
+    # v0 still holds deviceIdString from EditText. .locals 4 is active.
+    # Get SplashRTX context
+    iget-object v1, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$2;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX; # v1 is SplashRTX context
 
-    # finish() call (from previous diag step) also remains REMOVED from this path
-    # iget-object v1, p0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$2;->this$0:Lcom/rtx/nextvproject/RTX/UI/SplashRTX;
-    # invoke-virtual {v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    # Call DeviceApiHandler.checkDeviceStatus(context, deviceIdString)
+    invoke-static {v1, v0}, Lcom/rtx/nextvproject/RTX/Network/DeviceApiHandler;->checkDeviceStatus(Landroid/content/Context;Ljava/lang/String;)Ljava/lang/String;
+    move-result-object v2 # v2 is check_status_response
+
+    # Check response for errors
+    const-string v3, "\"status\":\"error\"" # v3 is error_substring
+    invoke-virtual {v2, v3}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+    move-result v2 # v2 is now contains_error (boolean, 0 or 1)
+
+    if-eqz v2, :cond_local_check_ok # If contains_error is false (0), no error, proceed.
+
+    # Error found in local check response: Finish SplashRTX
+    # v1 still holds SplashRTX context
+    invoke-virtual {v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    goto :goto_0 # Jump to the common return point
+
+    :cond_local_check_ok
+    # No error, proceed to launch TvActivity
+    # v1 still holds SplashRTX context
+    new-instance v2, Landroid/content/Intent; # v2 is new Intent
+    const-class v3, Lfr/nextv/atv/app/TvActivity; # v3 is TvActivity.class
+    invoke-direct {v2, v1, v3}, Landroid/content/Intent;-><init>(Landroid/content/Context;Ljava/lang/Class;)V
+
+    # v1 still SplashRTX context
+    invoke-virtual {v1, v2}, Landroid/app/Activity;->startActivity(Landroid/content/Intent;)V
+
+    # v1 still SplashRTX context
+    invoke-virtual {v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    # ---- END OF DEVICE ID CHECK & TVActivity LAUNCH ----
 
     goto :goto_0
 .end method

--- a/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
+++ b/streambuddyRC/smali_classes5/com/rtx/nextvproject/RTX/UI/SplashRTX.smali
@@ -204,12 +204,35 @@
     return-void
 
 :cond_proceed_original_logic
-    # If device_id is found, call continueWithAppLogic with a null Bundle.
-    # p0 is 'this' (SplashRTX instance).
-    # .locals 5 is defined for the method. v0,v1,v2 used for SP. v3 for null.
+    # If device_id is found (in v1), directly check its status and proceed.
+    # p0 is SplashRTX context. v1 is deviceIdString.
+    # .locals 5 is defined. v0,v1,v2 used for SP. v2,v3,v4 available for use here.
 
-    const/4 v3, 0x0 # Using v3 for the null Bundle argument.
-    invoke-direct {p0, v3}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->continueWithAppLogic(Landroid/os/Bundle;)V
+    # Call DeviceApiHandler.checkDeviceStatus(context, deviceIdString)
+    # p0 is context, v1 is deviceIdString from SharedPreferences
+    invoke-static {p0, v1}, Lcom/rtx/nextvproject/RTX/Network/DeviceApiHandler;->checkDeviceStatus(Landroid/content/Context;Ljava/lang/String;)Ljava/lang/String;
+    move-result-object v2 # v2 gets check_status_response
+
+    # Check response for errors
+    const-string v3, "\"status\":\"error\"" # v3 gets error_substring
+    invoke-virtual {v2, v3}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+    move-result v4 # v4 gets contains_error (boolean)
+
+    if-eqz v4, :cond_local_check_ok_startup # If contains_error (v4) is false (0), no error, proceed.
+
+    # Error found in local check response: Finish SplashRTX
+    invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
+    return-void
+
+    :cond_local_check_ok_startup
+    # No error, proceed to launch TvActivity
+    new-instance v2, Landroid/content/Intent; # v2 is now new Intent
+    # p0 is context
+    const-class v3, Lfr/nextv/atv/app/TvActivity; # v3 is now TvActivity.class
+    invoke-direct {v2, p0, v3}, Landroid/content/Intent;-><init>(Landroid/content/Context;Ljava/lang/Class;)V
+
+    invoke-virtual {p0, v2}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->startActivity(Landroid/content/Intent;)V
+    invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->finish()V
 
     return-void
 .end method
@@ -294,44 +317,11 @@
 .end method
 
 .method continueWithAppLogic(Landroid/os/Bundle;)V
-    .locals 4 # Max register used is v3, so 4 locals
-    .param p1, "savedInstanceState"    # Landroid/os/Bundle;
+    .locals 0 # Method made empty for diagnostics
+    .param p1, "savedInstanceState"    # Landroid/os/Bundle; # p0 is 'this'
 
     .prologue
-    # Restoring HttpsGetTask and downImage calls.
-    # .locals 4 is already defined for the method.
-    # p0 is 'this' SplashRTX instance.
-    # p1 (savedInstanceState) is not used in this restored logic.
-
-    # Start HttpsGetTask
-    new-instance v0, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;
-    const/4 v1, 0x0 # Second argument for HttpsGetTask constructor (SplashRTX$1)
-    invoke-direct {v0, p0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;-><init>(Lcom/rtx/nextvproject/RTX/UI/SplashRTX;Lcom/rtx/nextvproject/RTX/UI/SplashRTX$1;)V
-
-    const/4 v1, 0x1 # Create a 1-element String array
-    new-array v1, v1, [Ljava/lang/String;
-
-    new-instance v2, Ljava/lang/StringBuilder;
-    invoke-direct {v2}, Ljava/lang/StringBuilder;-><init>()V
-
-    # Get production API URL from mConfig
-    sget-object v3, Lcom/rtx/nextvproject/RTX/mConfig;->mApiUrl:Ljava/lang/String;
-    invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-
-    const-string v3, "api/dns.php"
-    invoke-virtual {v2, v3}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-
-    invoke-virtual {v2}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
-    move-result-object v2
-
-    const/4 v3, 0x0 # Array index for the URL
-    aput-object v2, v1, v3
-
-    invoke-virtual {v0, v1}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX$HttpsGetTask;->execute([Ljava/lang/Object;)Landroid/os/AsyncTask;
-
-    # Call downImage - Temporarily REMOVED for diagnostics
-    # invoke-virtual {p0}, Lcom/rtx/nextvproject/RTX/UI/SplashRTX;->downImage()V
-
+    # Method body is now empty for diagnostic purposes.
     return-void
 .end method
 


### PR DESCRIPTION
…on the local device activation flow.

Here's a summary of what I did:

This commit modifies the application startup to concentrate solely on the local device ID verification flow, bypassing the production API call for `api/dns.php` for diagnostic purposes.

Changes:
1.  `SplashRTX.smali` (`continueWithAppLogic` method):
    - This method is now empty, ensuring no production API tasks are initiated through it.
2.  `SplashRTX$2.smali` (Save button listener):
    - After saving a non-empty Device ID (using `commit()`) and dismissing the dialog, this listener now directly calls `DeviceApiHandler.checkDeviceStatus` (which targets `http://localhost:5001/api/check_device_status`).
    - If the local check indicates success (no "error" in response), it launches `TvActivity` and finishes `SplashRTX`.
    - If the local check indicates an error, it finishes `SplashRTX`.
3.  `SplashRTX.smali` (`originalOnCreateLogicOrShowDialog` method):
    - In the path where a `device_id` is found in SharedPreferences, it now also directly calls `DeviceApiHandler.checkDeviceStatus` (targeting `http://localhost:5001/...`).
    - Similar to the save listener, if the local check is successful, it launches `TvActivity` and finishes `SplashRTX`.
    - If the local check indicates an error, it finishes `SplashRTX`.
4.  `DeviceApiHandler.smali`:
    - The URL for `checkDeviceStatus` is confirmed to be `http://localhost:5001/api/check_device_status?deviceId=`.

This setup aims to thoroughly test the local device activation logic in isolation across different launch scenarios and server responses.